### PR TITLE
Fix harbor widget description string

### DIFF
--- a/src/components/HarborRepository/HarborRepository.tsx
+++ b/src/components/HarborRepository/HarborRepository.tsx
@@ -89,9 +89,7 @@ export function HarborRepository(props: RepositoryProps) {
             '#ff471a',
           ]}
           customSegmentStops={[0, 100, 200, 300, 400, 500]}
-          currentValueText={`${props.host}${props.host ? '/' : ''}${
-            props.project
-          }/${props.repository}`}
+          currentValueText={truncateGraphDescription(props.host, props.project, props.repository)}
           customSegmentLabels={[
             {
               text: 'None',
@@ -124,6 +122,20 @@ export function HarborRepository(props: RepositoryProps) {
       />
     </div>
   )
+}
+
+function truncateGraphDescription (host: string, project: string, repository: string) {
+  let descriptionString = `${host}${host ? '/' : ''}${
+    project
+  }/${repository}`
+  if (descriptionString.length > 38) {
+    descriptionString = `${project}/${repository}`
+    if (descriptionString.length > 38) {
+      return repository
+    }
+    return descriptionString
+  }
+  return descriptionString;
 }
 
 HarborRepository.defaultProps = {


### PR DESCRIPTION
Hey,
when we have added Harbor Widget to our Backstage instance we noticed that the `descriptionString` is cut if too long and we are unable to see the Harbor repository name. 
![image](https://github.com/container-registry/backstage-plugin-harbor/assets/26680362/4e333b64-413e-453f-9be7-34e667f3e157)
In the screenshot above you can see that we can only see the part of the `harbor host url` and part of the `harbor project name`.
This PR adds length check of the `descriptionString` and if it's too long it removes `host` from it, if it's still too long it returns only the `repository`.
Result:
![image](https://github.com/container-registry/backstage-plugin-harbor/assets/26680362/9e6a0b54-f14d-4cff-add4-cd31960dc1c6)
Now there is a `project/repository` visible